### PR TITLE
Add SwipeBehavior (Bot API 7.7)

### DIFF
--- a/.changeset/ninety-pumas-beg.md
+++ b/.changeset/ninety-pumas-beg.md
@@ -1,0 +1,13 @@
+---
+"@telegram-apps/sdk-react": minor
+"@telegram-apps/sdk-solid": minor
+"@telegram-apps/sdk": minor
+"docs": minor
+---
+
+Add SwipeBehavior component for Telegram Bot API 7.7 support
+
+- Implement new SwipeBehavior component to interface with Telegram's WebApp
+- Add `isVerticalSwipesEnabled` property to SwipeBehavior
+- Implement `enableVerticalSwipes()` method in SwipeBehavior
+- Implement `disableVerticalSwipes()` method in SwipeBehavior

--- a/apps/docs/.vitepress/packages.ts
+++ b/apps/docs/.vitepress/packages.ts
@@ -24,6 +24,7 @@ export const packagesSidebar = {
               BackButton: 'back-button',
               BiometryManager: 'biometry-manager',
               ClosingBehavior: 'closing-behavior',
+              SwipeBehavior: 'swipe-behavior',
               CloudStorage: 'cloud-storage',
               HapticFeedback: 'haptic-feedback',
               InitData: 'init-data',

--- a/apps/docs/packages/telegram-apps-sdk-react.md
+++ b/apps/docs/packages/telegram-apps-sdk-react.md
@@ -191,11 +191,12 @@ internally.
 
 ## Hooks and HOCs List
 
-| Hook and HOC (Raw)                                | Hook and HOC (Result)                       | Returned value                                                              |
-|---------------------------------------------------|---------------------------------------------|-----------------------------------------------------------------------------|
+| Hook and HOC (Raw)                                | Hook and HOC (Result)                       | Returned value                                                                     |
+|---------------------------------------------------|---------------------------------------------|------------------------------------------------------------------------------------|
 | `useBackButtonRaw`, `withBackButtonRaw`           | `useBackButton`, `withBackButton`           | [BackButton](telegram-apps-sdk/components/back-button.md)                          |
 | `useBiometryManagerRaw`, `withBiometryManagerRaw` | `useBiometryManager`, `withBiometryManager` | [BiometryManager](telegram-apps-sdk/components/biometry-manager.md) or `undefined` |
 | `useClosingBehaviorRaw`, `withClosingBehaviorRaw` | `useClosingBehavior`, `withClosingBehavior` | [ClosingBehavior](telegram-apps-sdk/components/closing-behavior.md)                |
+| `useSwipeBehaviorRaw`, `withSwipeBehaviorRaw`     | `useSwipeBehavior`, `withSwipeBehavior`     | [SwipeBehavior](telegram-apps-sdk/components/swipe-behavior.md)                    |
 | `useCloudStorageRaw`, `withCloudStorageRaw`       | `useCloudStorage`, `withCloudStorage`       | [CloudStorage](telegram-apps-sdk/components/cloud-storage.md)                      |
 | `useHapticFeedbackRaw`, `withHapticFeedbackRaw`   | `useHapticFeedback`, `withHapticFeedback`   | [HapticFeedback](telegram-apps-sdk/components/haptic-feedback.md)                  |
 | `useInitDataRaw`, `withInitDataRaw`               | `useInitData`, `withInitData`               | [InitData](telegram-apps-sdk/components/init-data.md)                              |

--- a/apps/docs/packages/telegram-apps-sdk-solid.md
+++ b/apps/docs/packages/telegram-apps-sdk-solid.md
@@ -143,11 +143,12 @@ hook result. Note that the received value will be a signal, not the value behind
 
 ## Hooks and HOCs List
 
-| Hook                 | HOC                   | Signal value                                                                |
-|----------------------|-----------------------|-----------------------------------------------------------------------------|
+| Hook                 | HOC                   | Signal value                                                                       |
+|----------------------|-----------------------|------------------------------------------------------------------------------------|
 | `useBackButton`      | `withBackButton`      | [BackButton](telegram-apps-sdk/components/back-button.md)                          |
 | `useBiometryManager` | `withBiometryManager` | [BiometryManager](telegram-apps-sdk/components/biometry-manager.md) or `undefined` |
-| `useClosingBehavior` | `withClosingBehavior` | [ClosingBehavior](telegram-apps-sdk/components/closing-behavior.md)                |
+| `useClosingBehavior` | `withClosingBehavior` | [ClosingBehavior](telegram-apps-sdk/components/closing-behavior.md)<br/>           |
+| `useSwipeBehavior`   | `withSwipeBehavior`   | [SwipeBehavior](telegram-apps-sdk/components/swipe-behavior.md)<br/>               |
 | `useCloudStorage`    | `withCloudStorage`    | [CloudStorage](telegram-apps-sdk/components/cloud-storage.md)                      |
 | `useHapticFeedback`  | `withHapticFeedback`  | [HapticFeedback](telegram-apps-sdk/components/haptic-feedback.md)                  |
 | `useInitData`        | `withInitData`        | [InitData](telegram-apps-sdk/components/init-data.md)                              |

--- a/apps/docs/packages/telegram-apps-sdk/components/swipe-behavior.md
+++ b/apps/docs/packages/telegram-apps-sdk/components/swipe-behavior.md
@@ -1,0 +1,36 @@
+# `SwipeBehavior`
+
+Implements Telegram Mini
+Apps [swipe behavior](../../../platform/swipe-behavior.md) functionality.
+
+## Initialization
+
+To initialize the component, use the `initSwipeBehavior` function:
+
+```typescript
+import {initSwipeBehavior} from '@telegram-apps/sdk';
+
+const [swipeBehavior] = initSwipeBehavior();  
+```
+
+## Swipe Behavior
+
+To enable and disable vertical swipes, it is required to use `enableVerticalSwipes()`
+and `disableVerticalSwipes()` methods. These methods update `isVerticalSwipesEnabled` property:
+
+```typescript  
+swipeBehavior.enableVerticalSwipes();
+console.log(swipeBehavior.isVerticalSwipesEnabled); // true  
+
+swipeBehavior.disableVerticalSwipes();
+console.log(swipeBehavior.isVerticalSwipesEnabled); // false
+```
+
+## Events
+
+List of events, which could be [tracked](../components#events):
+
+| Event                            | Listener                   | Triggered when                             |
+|----------------------------------|----------------------------|--------------------------------------------|
+| `change`                         | `() => void`               | Something in component changed             |
+| `change:isVerticalSwipesEnabled` | `(value: boolean) => void` | `isVerticalSwipesEnabled` property changed |

--- a/apps/docs/platform/methods.md
+++ b/apps/docs/platform/methods.md
@@ -440,6 +440,16 @@ Updates current [closing behavior](closing-behavior.md).
 |-------------------|-----------|----------------------------------------------------------------------|
 | need_confirmation | `boolean` | Will user be prompted in case, an application is going to be closed. |
 
+### `web_app_setup_swipe_behavior`
+
+Available since: **v7.7**
+
+Updates current [swipe behavior](swipe-behavior.md).
+
+| Field                | Type      | Description                                                                                                                                                                                                                                                     |
+|----------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| allow_vertical_swipe | `boolean` | True, if vertical swipes to close or minimize the Mini App are enabled. False, if vertical swipes to close or minimize the Mini App are disabled. In any case, the user will still be able to minimize and close the Mini App by swiping the Mini App's header. |
+
 ### `web_app_setup_main_button`
 
 Updates the [Main Button](main-button.md) settings.

--- a/apps/docs/platform/swipe-behavior.md
+++ b/apps/docs/platform/swipe-behavior.md
@@ -1,0 +1,11 @@
+# Swipe Behavior
+
+Mini Apps are intended to handle different, and at times, complex scenarios where the user can
+navigate deep into the application architecture. It's a common situation when a user is following a
+specific workflow, such as purchasing an airplane ticket, which involves multiple steps.
+
+Accidentally swiping down a Mini App can be a significant disappointment for the user. To
+prevent this, developers have the option to configure the swipe behavior, so application won't hide in the dock.
+
+To enable swipe confirmation, Telegram Mini Apps provides a method
+called [web_app_setup_swipe_behavior](methods.md#web-app-setup-swipe-behavior).

--- a/packages/sdk-react/src/hooks-hocs/swipe-behavior.ts
+++ b/packages/sdk-react/src/hooks-hocs/swipe-behavior.ts
@@ -1,0 +1,11 @@
+import { initSwipeBehavior } from '@telegram-apps/sdk';
+
+import { createHOCs } from '../createHOCs.js';
+import { createHooks } from '../createHooks.js';
+
+export const [useSwipeBehaviorRaw, useSwipeBehavior] = createHooks(initSwipeBehavior);
+
+export const [withSwipeBehaviorRaw, withSwipeBehavior] = createHOCs(
+  useSwipeBehaviorRaw,
+  useSwipeBehavior,
+);

--- a/packages/sdk-solid/src/hooks-hocs/swipe-behavior.ts
+++ b/packages/sdk-solid/src/hooks-hocs/swipe-behavior.ts
@@ -1,0 +1,14 @@
+import { initSwipeBehavior } from '@telegram-apps/sdk';
+
+import { createHOC } from '../createHOC.js';
+import { createHook } from '../createHook.js';
+
+/**
+ * Hook to receive the SwipeBehavior component instance.
+ */
+export const useSwipeBehavior = createHook(initSwipeBehavior);
+
+/**
+ * HOC to pass the SwipeBehavior component instance to the wrapped component.
+ */
+export const withSwipeBehavior = createHOC(useSwipeBehavior);

--- a/packages/sdk/src/bridge/methods/types/methods.ts
+++ b/packages/sdk/src/bridge/methods/types/methods.ts
@@ -294,6 +294,19 @@ export interface MiniAppsMethods {
     need_confirmation: boolean;
   }>;
   /**
+   * Updates current swipe behavior
+   * @since v7.7
+   * @see https://docs.telegram-mini-apps.com/platform/methods#web-app-setup-closing-behavior
+   */
+  web_app_setup_swipe_behavior: CreateParams<{
+    /**
+     *  True, if vertical swipes to close or minimize the Mini App are enabled.
+     *  False, if vertical swipes to close or minimize the Mini App are disabled.
+     *  In any case, the user will still be able to minimize and close the Mini App by swiping the Mini App's header.
+     */
+    allow_vertical_swipe: boolean;
+  }>;
+  /**
    * Updates the Main Button settings.
    * @see https://docs.telegram-mini-apps.com/platform/methods#web-app-setup-main-button
    */

--- a/packages/sdk/src/components/SwipeBehavior/SwipeBehavior.test.ts
+++ b/packages/sdk/src/components/SwipeBehavior/SwipeBehavior.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SwipeBehavior } from './SwipeBehavior.js';
+
+describe('disable', () => {
+  it('should call "web_app_setup_swipe_behavior" method with "allow_vertical_swipe" equal to false', () => {
+    const postEvent = vi.fn();
+    const confirmation = new SwipeBehavior(true, postEvent);
+
+    expect(postEvent).toHaveBeenCalledTimes(0);
+    confirmation.disableVerticalSwipes();
+    expect(postEvent).toHaveBeenCalledTimes(1);
+    expect(postEvent).toHaveBeenCalledWith('web_app_setup_swipe_behavior', { allow_vertical_swipe: false });
+  });
+
+  it('should emit "isVerticalSwipesEnabledChanged" event with false value', () => {
+    const confirmation = new SwipeBehavior(true, vi.fn());
+    const listener = vi.fn();
+
+    confirmation.on('change:isVerticalSwipesEnabled', listener);
+    expect(listener).toHaveBeenCalledTimes(0);
+    confirmation.disableVerticalSwipes();
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('enable', () => {
+  it('should call "web_app_setup_swipe_behavior" method with "allow_vertical_swipe" equal to true', () => {
+    const postEvent = vi.fn();
+    const confirmation = new SwipeBehavior(false, postEvent);
+
+    expect(postEvent).toHaveBeenCalledTimes(0);
+    confirmation.enableVerticalSwipes();
+    expect(postEvent).toHaveBeenCalledTimes(1);
+    expect(postEvent).toHaveBeenCalledWith('web_app_setup_swipe_behavior', { allow_vertical_swipe: true });
+  });
+
+  it('should emit "isVerticalSwipesEnabledChanged" event with true value', () => {
+    const confirmation = new SwipeBehavior(false, vi.fn());
+    const listener = vi.fn();
+
+    confirmation.on('change:isVerticalSwipesEnabled', listener);
+    expect(listener).toHaveBeenCalledTimes(0);
+    confirmation.enableVerticalSwipes();
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('on', () => {
+  describe('"isVerticalSwipesEnabledChanged" event', () => {
+    it('should add event listener to event', () => {
+      const listener = vi.fn();
+      const confirmation = new SwipeBehavior(false, vi.fn());
+
+      confirmation.on('change:isVerticalSwipesEnabled', listener);
+
+      expect(listener).toHaveBeenCalledTimes(0);
+      confirmation.enableVerticalSwipes();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('off', () => {
+  describe('"isVerticalSwipesEnabledChanged" event', () => {
+    it('should remove event listener from event', () => {
+      const listener = vi.fn();
+      const confirmation = new SwipeBehavior(false, vi.fn());
+
+      confirmation.on('change:isVerticalSwipesEnabled', listener);
+
+      expect(listener).toHaveBeenCalledTimes(0);
+      confirmation.enableVerticalSwipes();
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      confirmation.off('change:isVerticalSwipesEnabled', listener);
+      listener.mockClear();
+
+      expect(listener).toHaveBeenCalledTimes(0);
+      confirmation.disableVerticalSwipes();
+      expect(listener).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/packages/sdk/src/components/SwipeBehavior/SwipeBehavior.ts
+++ b/packages/sdk/src/components/SwipeBehavior/SwipeBehavior.ts
@@ -1,0 +1,41 @@
+import { WithTrackableState } from '@/classes/WithTrackableState.js';
+import type { PostEvent } from '@/bridge/methods/postEvent.js';
+import type { SwipeBehaviorState } from '@/components/SwipeBehavior/types.js';
+
+/**
+ * @see Usage: https://docs.telegram-mini-apps.com/platform/swipe-behavior
+ * @see API: https://docs.telegram-mini-apps.com/packages/telegram-apps-sdk/components/swipe-behavior
+ */
+export class SwipeBehavior extends WithTrackableState<SwipeBehaviorState> {
+  constructor(isVerticalSwipesEnabled: boolean, private readonly postEvent: PostEvent) {
+    super({ isVerticalSwipesEnabled });
+  }
+
+  private set isVerticalSwipesEnabled(value: boolean) {
+    this.set('isVerticalSwipesEnabled', value);
+    this.postEvent('web_app_setup_swipe_behavior', { allow_vertical_swipe: value });
+  }
+
+  /**
+   * True, if vertical swipes to close or minimize the Mini App are enabled.
+   * False, if vertical swipes to close or minimize the Mini App are disabled.
+   * In any case, the user will still be able to minimize and close the Mini App by swiping the Mini App's header.
+   */
+  get isVerticalSwipesEnabled(): boolean {
+    return this.get('isVerticalSwipesEnabled');
+  }
+
+  /**
+   * Disables vertical swipes to close or minimize the Mini App.
+   */
+  disableVerticalSwipes(): void {
+    this.isVerticalSwipesEnabled = false;
+  }
+
+  /**
+   * Enables vertical swipes to close or minimize the Mini App.
+   */
+  enableVerticalSwipes(): void {
+    this.isVerticalSwipesEnabled = true;
+  }
+}

--- a/packages/sdk/src/components/SwipeBehavior/initSwipeBehavior.ts
+++ b/packages/sdk/src/components/SwipeBehavior/initSwipeBehavior.ts
@@ -10,6 +10,6 @@ export const initSwipeBehavior = createComponentInitFn(
   'swipeBehavior',
   ({
     postEvent,
-    state = { isVerticalSwipesEnabled: false },
+    state = { isVerticalSwipesEnabled: true },
   }) => new SwipeBehavior(state.isVerticalSwipesEnabled, postEvent),
 );

--- a/packages/sdk/src/components/SwipeBehavior/initSwipeBehavior.ts
+++ b/packages/sdk/src/components/SwipeBehavior/initSwipeBehavior.ts
@@ -1,0 +1,15 @@
+import { createComponentInitFn } from '@/misc/createComponentInitFn/createComponentInitFn.js';
+
+import { SwipeBehavior } from './SwipeBehavior.js';
+
+/**
+ * @returns A new initialized instance of the `SwipeBehavior` class.
+ * @see SwipeBehavior
+ */
+export const initSwipeBehavior = createComponentInitFn(
+  'swipeBehavior',
+  ({
+    postEvent,
+    state = { isVerticalSwipesEnabled: false },
+  }) => new SwipeBehavior(state.isVerticalSwipesEnabled, postEvent),
+);

--- a/packages/sdk/src/components/SwipeBehavior/types.ts
+++ b/packages/sdk/src/components/SwipeBehavior/types.ts
@@ -1,0 +1,24 @@
+import type { StateEvents } from '@/classes/State/types.js';
+
+/**
+ * Swipe internal state.
+ */
+export interface SwipeBehaviorState {
+  isVerticalSwipesEnabled: boolean;
+}
+
+/**
+ * SwipeBehavior trackable events.
+ */
+export type SwipeBehaviorEvents = StateEvents<SwipeBehaviorState>;
+
+/**
+ * SwipeBehavior event name.
+ */
+export type SwipeBehaviorEventName = keyof SwipeBehaviorEvents;
+
+/**
+ * SwipeBehavior event listener.
+ */
+export type SwipeBehaviorEventListener<E extends SwipeBehaviorEventName> =
+  SwipeBehaviorEvents[E];

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -71,6 +71,16 @@ export type {
   ClosingBehaviorState,
 } from '@/components/ClosingBehavior/types.js';
 
+// SwipeBehavior.
+export { SwipeBehavior } from '@/components/SwipeBehavior/SwipeBehavior.js';
+export { initSwipeBehavior } from '@/components/SwipeBehavior/initSwipeBehavior.js';
+export type {
+  SwipeBehaviorEventListener,
+  SwipeBehaviorEventName,
+  SwipeBehaviorEvents,
+  SwipeBehaviorState,
+} from '@/components/SwipeBehavior/types.js';
+
 // CloudStorage.
 export { CloudStorage } from '@/components/CloudStorage/CloudStorage.js';
 export { initCloudStorage } from '@/components/CloudStorage/initCloudStorage.js';

--- a/packages/sdk/src/storage/storage.ts
+++ b/packages/sdk/src/storage/storage.ts
@@ -1,6 +1,7 @@
 import type { BackButtonState } from '@/components/BackButton/types.js';
 import type { BiometryManagerState } from '@/components/BiometryManager/types.js';
 import type { ClosingBehaviorState } from '@/components/ClosingBehavior/types.js';
+import type { SwipeBehaviorState } from '@/components/SwipeBehavior/types.js';
 import type { MainButtonState } from '@/components/MainButton/types.js';
 import type { MiniAppState } from '@/components/MiniApp/types.js';
 import type { SettingsButtonState } from '@/components/SettingsButton/types.js';
@@ -14,6 +15,7 @@ export interface StorageParams {
   backButton: BackButtonState;
   biometryManager: BiometryManagerState;
   closingBehavior: ClosingBehaviorState;
+  swipeBehavior: SwipeBehaviorState;
   launchParams: string;
   mainButton: MainButtonState;
   miniApp: MiniAppState;

--- a/packages/sdk/src/supports/supports.test.ts
+++ b/packages/sdk/src/supports/supports.test.ts
@@ -102,6 +102,9 @@ describe.each<[
       parameter: 'return_back',
     },
   ]],
+  ['7.7', [
+    'web_app_setup_swipe_behavior',
+  ]],
 ])('%s', (version, methods) => {
   const higher = increaseVersion(version, 1);
   const lower = increaseVersion(version, -1);

--- a/packages/sdk/src/supports/supports.ts
+++ b/packages/sdk/src/supports/supports.ts
@@ -89,6 +89,8 @@ export function supports(
     case 'web_app_biometry_request_auth':
     case 'web_app_biometry_update_token':
       return versionLessOrEqual('7.2', paramOrVersion);
+    case 'web_app_setup_swipe_behavior':
+      return versionLessOrEqual('7.7', paramOrVersion);
     default:
       return [
         'iframe_ready',


### PR DESCRIPTION
# Add SwipeBehavior (Bot API 7.7)

### Add SwipeBehavior component for Telegram Bot API 7.7 support

- Implement new SwipeBehavior component to interface with Telegram's WebApp
- Add `isVerticalSwipesEnabled` property to SwipeBehavior
- Implement `enableVerticalSwipes()` method in SwipeBehavior
- Implement `disableVerticalSwipes()` method in SwipeBehavior

### Code added in [telegram-web-app.js](https://telegram.org/js/telegram-web-app.js):
```js
var isVerticalSwipesEnabled = true;
WebApp.enableVerticalSwipes = function() {
  WebApp.isVerticalSwipesEnabled = true;
};
WebApp.disableVerticalSwipes = function() {
  WebApp.isVerticalSwipesEnabled = false;
};
Object.defineProperty(WebApp, 'isVerticalSwipesEnabled', {
    set: function(val){ toggleVerticalSwipes(val); },
    get: function(){ return isVerticalSwipesEnabled; },
    enumerable: true
});
function toggleVerticalSwipes(enable_swipes) {
  if (!versionAtLeast('7.7')) {
    console.warn('[Telegram.WebApp] Changing swipes behavior is not supported in version ' + webAppVersion);
    return;
  }
  isVerticalSwipesEnabled = !!enable_swipes;
  WebView.postEvent('web_app_setup_swipe_behavior', false, {allow_vertical_swipe: isVerticalSwipesEnabled});
}
 ```