### PR TITLE
Update cloud-storage.md

### DIFF
--- a/apps/docs/packages/telegram-apps-sdk/components/cloud-storage.md
+++ b/apps/docs/packages/telegram-apps-sdk/components/cloud-storage.md
@@ -9,7 +9,7 @@ To initialize the component, use the `initCloudStorage` function:
 ```typescript
 import { initCloudStorage } from '@telegram-apps/sdk';
 
-const [cloudStorage] = initCloudStorage();  
+const cloudStorage = initCloudStorage();  
 ```
 
 ## Setting Items


### PR DESCRIPTION
Square brackets around const [cloudStorage] give an error TypeError: initCloudStorage is not a function or its return value is not iterable. Removed them