### PR TITLE
[docs: init-data.md] Fix `initInitData()` func init description

### DIFF
--- a/apps/docs/packages/telegram-apps-sdk/components/init-data.md
+++ b/apps/docs/packages/telegram-apps-sdk/components/init-data.md
@@ -14,7 +14,7 @@ To initialize the component, use the `initInitData` function:
 ```typescript
 import { initInitData } from '@telegram-apps/sdk';
 
-const [initData] = initInitData();  
+const initData = initInitData();
 ```
 
 ## Properties


### PR DESCRIPTION
Fix `initInitData()` func init description, because it doesn't have `clean` func.

<img width="960" alt="Снимок экрана 2024-08-15 в 07 52 37" src="https://github.com/user-attachments/assets/1c37b46e-2598-491c-80d2-72fcc6e9ddb8">

Right way to init:

```ts
const initData = initInitData();
```