### PR TITLE
[docs: popup.md] Fix `initPopup()` func init description

### DIFF
--- a/apps/docs/packages/telegram-apps-sdk/components/popup.md
+++ b/apps/docs/packages/telegram-apps-sdk/components/popup.md
@@ -9,7 +9,7 @@ To initialize the component, use the `initPopup` function:
 ```typescript
 import { initPopup } from '@telegram-apps/sdk';
 
-const [popup] = initPopup();  
+const popup = initPopup();  
 ```
 
 ## Opening New Popup


### PR DESCRIPTION
Fix `initPopup()` func init description, because it doesn't have clean func.

<img width="599" alt="Снимок экрана 2024-08-16 в 10 29 58" src="https://github.com/user-attachments/assets/157dd286-43f7-442c-9824-cd4526521a63">

Right way to init:

```ts
const popup = initPopup();
```