### PR TITLE
updated the startapp param max length

### DIFF
--- a/apps/docs/platform/start-parameter.md
+++ b/apps/docs/platform/start-parameter.md
@@ -38,6 +38,6 @@ data's [start_param](init-data.md#parameters-list) property.
 
 ## Restrictions
 
-- Maximum length: **64 symbols**
+- Maximum length: **512 symbols**
 - Allowed symbols: **latin alphabet symbols, digits** and **underscore**. The valid regexp for the value
-  is `/[\w]{0,64}/`.
+  is `/[\w]{0,512}/`.


### PR DESCRIPTION
updated information about the maximum length of the startapp parameter https://core.telegram.org/bots/api-changelog#august-18-2023