### PR TITLE
Update useTelegramMock.ts to prevent error

### DIFF
--- a/playgrounds/next/src/hooks/useTelegramMock.ts
+++ b/playgrounds/next/src/hooks/useTelegramMock.ts
@@ -60,7 +60,7 @@ export function useTelegramMock(): void {
       },
       initData: InitData.parse(initDataRaw),
       initDataRaw,
-      version: '7.2',
+      version: '7.10',
       platform: 'tdesktop',
     });
     sessionStorage.setItem(MOCK_KEY, '1');


### PR DESCRIPTION
Changed 7.2 to 7.10

If you leave: 7.2 instead of latest

Error: Method "web_app_set_bottom_bar_color" is unsupported in Mini Apps version 7.2