### PR TITLE
fix qr scanner capture logic

### DIFF
--- a/.changeset/small-gifts-know.md
+++ b/.changeset/small-gifts-know.md
@@ -1,0 +1,5 @@
+---
+"@telegram-apps/sdk": patch
+---
+
+Fix qr scanner capture logic

--- a/packages/sdk/src/scopes/components/qr-scanner/qr-scanner.test.ts
+++ b/packages/sdk/src/scopes/components/qr-scanner/qr-scanner.test.ts
@@ -75,6 +75,19 @@ describe('open', () => {
       expect(spy).toHaveBeenCalledWith('web_app_close_scan_qr_popup', undefined);
     });
 
+    it('should call "web_app_close_scan_qr_popup" if QR was scanned', async () => {
+      const spy = mockPostEvent();
+      const promise = open();
+      spy.mockClear();
+      dispatchMiniAppsEvent("qr_text_received", { data: "QR1" });
+      await promise;
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(
+        "web_app_close_scan_qr_popup",
+        undefined
+      );
+    });
+
     it('should return promise with undefined if "scan_qr_popup_closed" event was received', async () => {
       const promise = open({
         capture() {

--- a/packages/sdk/src/scopes/components/qr-scanner/qr-scanner.ts
+++ b/packages/sdk/src/scopes/components/qr-scanner/qr-scanner.ts
@@ -103,7 +103,7 @@ export function open(options?: OpenSharedOptions & {
       on(SCANNED_EVENT, (event) => {
         if (onCaptured) {
           onCaptured(event.data);
-        } else if (capture && capture(event.data)) {
+        } else if (!capture || capture(event.data)) {
           promise.resolve(event.data);
           close();
         }


### PR DESCRIPTION
As stated in [docs](https://docs.telegram-mini-apps.com/packages/telegram-apps-sdk/2-x/components/qr-scanner#promise-style):

> Accepts the optional `capture` option receiving the scanned QR content and returning `true` if it should be captured and promise resolved. **If omitted, the first captured QR content will be resolved.**