### PR TITLE
fix: add support for the 'web_app_share_to_story' method check

### DIFF
--- a/packages/bridge/src/methods/supports.ts
+++ b/packages/bridge/src/methods/supports.ts
@@ -96,6 +96,8 @@ export function supports(
       return versionLessOrEqual('7.2', paramOrVersion);
     case 'web_app_setup_swipe_behavior':
       return versionLessOrEqual('7.7', paramOrVersion);
+    case 'web_app_share_to_story':
+      return versionLessOrEqual('7.8', paramOrVersion);
     case 'web_app_setup_secondary_button':
     case 'web_app_set_bottom_bar_color':
       return versionLessOrEqual('7.10', paramOrVersion);


### PR DESCRIPTION
I discovered that shareStory.isSupported was not supported in the current implementation. As a result, I have submitted a PR to add support for this method.