### PR TITLE
fix(mate): buffer types fix

### DIFF
--- a/.changeset/empty-ways-sparkle.md
+++ b/.changeset/empty-ways-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@telegram-apps/mate": patch
+---
+
+Use `Buffer.from` instead of `Buffer.concat` due to some problems related to monorepo typings.

--- a/packages/mate/src/compress/compress.ts
+++ b/packages/mate/src/compress/compress.ts
@@ -23,7 +23,7 @@ export function compress(
     let buffer = Buffer.from([]);
     stream.on('error', reject);
     stream.on('data', b => {
-      buffer = Buffer.concat([buffer, b]);
+      buffer = Buffer.from([...buffer, ...b]);
     });
     stream.on('end', () => resolve(buffer));
   });


### PR DESCRIPTION
Hi, when developing sdk-svelte and setting up typecheck for svelte I encountered global typecheck errors, which complained about buffer types. I fixed the above error in this pull request.
![2024-10-31_17-01-10](https://github.com/user-attachments/assets/7c80eb2b-38da-4cc9-a359-decf0f04ca57)
![2024-10-31_17-01-41](https://github.com/user-attachments/assets/8185f44a-0f82-40b9-9ffc-8778c3153130)
