### PR TITLE
fix(playgrounds): binding css variables after viewport mounting

### DIFF
--- a/playgrounds/next/src/init.ts
+++ b/playgrounds/next/src/init.ts
@@ -24,14 +24,15 @@ export function init(debug: boolean): void {
   miniApp.mount();
   themeParams.mount();
   initData.restore();
-  void viewport.mount().catch(e => {
+  
+  void viewport.mount().then(() => {
+    // Define components-related CSS variables.
+    viewport.bindCssVars();
+    miniApp.bindCssVars();
+    themeParams.bindCssVars();
+  }).catch((e: any) => {
     console.error('Something went wrong mounting the viewport', e);
   });
-
-  // Define components-related CSS variables.
-  viewport.bindCssVars();
-  miniApp.bindCssVars();
-  themeParams.bindCssVars();
 
   // Add Eruda if needed.
   debug && import('eruda')

--- a/playgrounds/react/src/init.ts
+++ b/playgrounds/react/src/init.ts
@@ -24,14 +24,15 @@ export function init(debug: boolean): void {
   miniApp.mount();
   themeParams.mount();
   initData.restore();
-  void viewport.mount().catch(e => {
+  
+  void viewport.mount().then(() => {
+    // Define components-related CSS variables.
+    viewport.bindCssVars();
+    miniApp.bindCssVars();
+    themeParams.bindCssVars();
+  }).catch((e: any) => {
     console.error('Something went wrong mounting the viewport', e);
   });
-
-  // Define components-related CSS variables.
-  viewport.bindCssVars();
-  miniApp.bindCssVars();
-  themeParams.bindCssVars();
 
   // Add Eruda if needed.
   debug && import('eruda')

--- a/playgrounds/solid/src/init.ts
+++ b/playgrounds/solid/src/init.ts
@@ -24,14 +24,15 @@ export function init(debug: boolean): void {
   miniApp.mount();
   themeParams.mount();
   initData.restore();
-  void viewport.mount().catch(e => {
+  
+  void viewport.mount().then(() => {
+    // Define components-related CSS variables.
+    viewport.bindCssVars();
+    miniApp.bindCssVars();
+    themeParams.bindCssVars();
+  }).catch((e: any) => {
     console.error('Something went wrong mounting the viewport', e);
   });
-
-  // Define components-related CSS variables.
-  viewport.bindCssVars();
-  miniApp.bindCssVars();
-  themeParams.bindCssVars();
 
   // Add Eruda if needed.
   debug && import('eruda')

--- a/playgrounds/vue/src/init.ts
+++ b/playgrounds/vue/src/init.ts
@@ -24,14 +24,15 @@ export function init(debug: boolean): void {
   miniApp.mount();
   themeParams.mount();
   initData.restore();
-  void viewport.mount().catch((e: any) => {
+
+  void viewport.mount().then(() => {
+    // Define components-related CSS variables.
+    viewport.bindCssVars();
+    miniApp.bindCssVars();
+    themeParams.bindCssVars();
+  }).catch((e: any) => {
     console.error('Something went wrong mounting the viewport', e);
   });
-
-  // Define components-related CSS variables.
-  viewport.bindCssVars();
-  miniApp.bindCssVars();
-  themeParams.bindCssVars();
 
   // Add Eruda if needed.
   debug && import('eruda')


### PR DESCRIPTION
Hi, I almost deployed a playground for sdk-svelte, but ran into a problem with initializing CSS variables - initialization starts before mounting the viewport. This problem is in all playgrounds.
![2024-11-01_02-31-39](https://github.com/user-attachments/assets/4dbd44b5-65de-45fc-b65f-40672ae72ae4)
![2024-11-01_02-01-13](https://github.com/user-attachments/assets/96b73aa9-2c8e-4274-a5a7-21613c7914d8)
