### PR TITLE
feat(docs): implement i18n meta tag

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -4,7 +4,7 @@ import { packagesLinksGenerator } from './packages';
 import { platformLinksGenerator } from './platform';
 
 import { zh } from "./zh/config";
-
+import { metaObject as zhMetaObject } from "./zh/meta";
 const { packagesNavItem, packagesSidebar } = packagesLinksGenerator();
 const { platformNavItem, platformSidebar } = platformLinksGenerator();
 
@@ -145,13 +145,27 @@ export default defineConfig({
 
     const addOg = (prop: string, content: string) => addMeta(`og:${prop}`, content);
 
-    addOg('title', isHome ? siteTitle : `${title} | ${siteTitle}`);
-    addOg('site_name', 'Telegram Mini Apps Platform Documentation');
-    addOg('image', `${siteBase}thumbnail-1200x630.6b8f54aa217a6baed4703ad5af866677.png`);
-    addOg('image:width', '1200');
-    addOg('image:height', '630');
-    addOg('image:type', 'image/png');
-    addOg('locale', lang.replace(/-/, '_'));
+    const i18nMeta = {
+      zh: zhMetaObject,
+    };
+
+    let baseMeta = {
+      site_name: 'Telegram Mini Apps Platform Documentation',
+      image: `${siteBase}thumbnail-1200x630.6b8f54aa217a6baed4703ad5af866677.png`,
+      'image:width': '1200',
+      'image:height': '630',
+      'image:type': 'image/png',
+      locale: lang.replace(/-/, '_'),
+      // for i18n
+      'locale:alternate': 'zh_CN',
+    };
+
+    const currentI18nMeta = Object.entries(i18nMeta).find(([key, _]) => filePath?.startsWith(`${key}/`))?.[1];
+
+    const i18nSiteTitle = currentI18nMeta?.title ?? siteTitle;
+    baseMeta = { ...baseMeta, ...currentI18nMeta, title: isHome ? i18nSiteTitle : `${title} | ${i18nSiteTitle}` } as typeof baseMeta;
+
+    Object.entries(baseMeta).forEach(([key, value]) => addOg(key, value));
 
     // To make it correctly display in Telegram.
     addMeta('twitter:card', 'summary_large_image');

--- a/apps/docs/.vitepress/zh/meta.ts
+++ b/apps/docs/.vitepress/zh/meta.ts
@@ -1,0 +1,5 @@
+export const metaObject = {
+  site_name: "Telegram 小程序平台文档",
+  title: "Telegram 小程序"
+};
+


### PR DESCRIPTION
## Feature
Added i18n metadata configuration support, allowing independent site titles and other metadata for different language versions.

preview: https://telegram-apps-git-i18nmeta-townsquarexyz.vercel.app

## Changes
- Added `apps/docs/.vitepress/zh/meta.ts` for Chinese metadata configuration
- Modified metadata handling logic in `config.mts` to merge base metadata with language-specific metadata based on current locale

## Configuration Example
```typescript
// apps/docs/.vitepress/zh/meta.ts
export const metaObject = {
  site_name: "Telegram Mini Apps Platform Documentation",
  title: "Telegram Mini Apps"
};
```

## Usage
1. Create `meta.ts` in the corresponding language directory
2. Export `metaObject` containing the required metadata
3. System will automatically merge base metadata with language-specific metadata based on current page locale

## Notes
- Language-specific metadata will override corresponding properties in base metadata
- Maintain consistent metadata structure across language versions for better maintainability