### PR TITLE
fix(bridge) change doc link in ERR_RETRIEVE_LP_FAILED error

### DIFF
--- a/.changeset/wild-bulldogs-grab.md
+++ b/.changeset/wild-bulldogs-grab.md
@@ -1,0 +1,5 @@
+---
+"@telegram-apps/bridge": patch
+---
+
+Update the link returned if the `retrieveLaunchParams` function failed.

--- a/packages/bridge/src/launch-params/retrieveLaunchParams.ts
+++ b/packages/bridge/src/launch-params/retrieveLaunchParams.ts
@@ -42,7 +42,7 @@ export function retrieveLaunchParams(): LaunchParams {
   throw new TypedError(ERR_RETRIEVE_LP_FAILED, [
     'Unable to retrieve launch parameters from any known source. Perhaps, you have opened your app outside Telegram?',
     '📖 Refer to docs for more information:',
-    'https://docs.telegram-mini-apps.com/packages/telegram-apps-sdk/environment',
+    'https://docs.telegram-mini-apps.com/packages/telegram-apps-bridge/environment',
     'Collected errors:',
     ...errors.map(e => `— ${unwrapError(e)}`),
   ].join('\n'));


### PR DESCRIPTION
Minor fix in `ERR_RETRIEVE_LP_FAILED` error that can be thrown by `retrieveLaunchParams()`.