### PR TITLE
 fix(sdk-react): make useSignal work with SSR 

### DIFF
--- a/.changeset/hot-tables-complain.md
+++ b/.changeset/hot-tables-complain.md
@@ -1,0 +1,5 @@
+---
+"@telegram-apps/sdk-react": minor
+---
+
+Prevent useSignal from erroring out during SSR by passing an optional getServerSnapshot function or the signal itself to useSyncExternalStore

--- a/packages/sdk-react/src/useSignal.ts
+++ b/packages/sdk-react/src/useSignal.ts
@@ -3,10 +3,19 @@ import { useSyncExternalStore } from 'react';
 /**
  * Returns the underlying signal value updating it each time the signal value changes.
  * @param signal - a signal.
+ * @param getServerSnapshot - an optional function returning the signal value snapshot. It is used only during SSR
+ * to provide an initial value of the signal. When not set, defaults to the signal itself.
  */
-export function useSignal<T>(signal: {
-  (): T;
-  sub(fn: VoidFunction): VoidFunction;
-}): T {
-  return useSyncExternalStore((onStoreChange) => signal.sub(onStoreChange), signal);
+export function useSignal<T>(
+  signal: {
+    (): T;
+    sub(fn: VoidFunction): VoidFunction;
+  },
+  getServerSnapshot?: () => T
+): T {
+  return useSyncExternalStore(
+    (onStoreChange) => signal.sub(onStoreChange),
+    signal,
+    getServerSnapshot || signal
+  );
 }


### PR DESCRIPTION
### Current behavior 

A component that uses `useSignal` will error out during server-side rendering. For example, a simple Client Component like this in NextJS App Router (though the problem is not specific to NextJS)

```
// SimpleComponent.jsx

'use client'

function SimpleComponent() {
  const isMounted = useSignal(backButton.isMounted)
  return <div>Back button is {isMounted ? 'mounted' : 'not mounted'}</div> 
}

// page.jsx

function Page() {
  ...
  return (
    <div>
      <SimpleComponent />
    </div>
  )
}
```

This will produce the following error

```
Error: Missing getServerSnapshot, which is required for server-rendered content. Will revert to client rendering.
```

### Desired behavior

The real value is only available in a browser, but the component should be able to render with some initial value on the server.


### Solution

from `useSyncExternalStore` [docs](https://react.dev/reference/react/useSyncExternalStore#parameters)
> optional getServerSnapshot: A function that returns the initial snapshot of the data in the store. It will be used only during server rendering and during hydration of server-rendered content on the client.
> If you omit this argument, rendering the component on the server will throw an error.

`useSyncExternalStore` has `getServerSnapshot` [argument](https://react.dev/reference/react/useSyncExternalStore#adding-support-for-server-rendering) exactly for this case. The proposed solution adds an optional second argument to `useSignal` that can be used if someone needs SSR. If SSR is not needed, the argument can be omitted.

**Example usage when SSR is needed**

`const isMounted = useSignal(backButton.isMounted, false)`

**Example usage when SSR is not needed**

`const isMounted = useSignal(backButton.isMounted)`

### Breaking changes

None