### PR TITLE
fix: Update `isSupported` check for `sendData` method

### DIFF
--- a/.changeset/wet-geckos-switch.md
+++ b/.changeset/wet-geckos-switch.md
@@ -1,0 +1,5 @@
+---
+"@telegram-apps/sdk": patch
+---
+
+Move inline check from sendData to switchInlineQuery.

--- a/packages/sdk/src/scopes/utilities/uncategorized/sendData.ts
+++ b/packages/sdk/src/scopes/utilities/uncategorized/sendData.ts
@@ -1,6 +1,8 @@
 import { wrapSafe } from '@/scopes/wrappers/wrapSafe.js';
 import { InvalidArgumentsError } from '@/errors.js';
-import { launchParams, postEvent } from '@/globals.js';
+import { postEvent } from '@/globals.js';
+
+const METHOD_NAME = 'web_app_data_send';
 
 /**
  * Sends data to the bot.
@@ -14,7 +16,6 @@ import { launchParams, postEvent } from '@/globals.js';
  * @param data - data to send to bot.
  * @throws {FunctionNotAvailableError} The function is not supported
  * @throws {FunctionNotAvailableError} The environment is unknown
- * @throws {FunctionNotAvailableError} The application must be launched in the inline mode
  * @throws {InvalidArgumentsError} Maximum size of data to send is 4096 bytes
  * @throws {InvalidArgumentsError} Attempted to send empty data
  * @example
@@ -31,15 +32,7 @@ export const sendData = wrapSafe(
         ? 'Maximum size of data to send is 4096 bytes'
         : 'Attempted to send empty data');
     }
-    postEvent('web_app_data_send', { data });
+    postEvent(METHOD_NAME, { data });
   },
-  {
-    isSupported() {
-      // tgWebAppData is set only when the app is launched
-      // via a keyboard button OR from inline mode
-      return launchParams().tgWebAppData !== undefined
-        ? 'The application must be launched via a keyboard button'
-        : undefined;
-    },
-  },
+  { isSupported: METHOD_NAME },
 );

--- a/packages/sdk/src/scopes/utilities/uncategorized/sendData.ts
+++ b/packages/sdk/src/scopes/utilities/uncategorized/sendData.ts
@@ -35,9 +35,11 @@ export const sendData = wrapSafe(
   },
   {
     isSupported() {
-      return launchParams().tgWebAppBotInline
-        ? undefined
-        : 'The application must be launched in the inline mode';
+      // tgWebAppData is set only when the app is launched
+      // via a keyboard button OR from inline mode
+      return launchParams().tgWebAppData !== undefined
+        ? 'The application must be launched via a keyboard button'
+        : undefined;
     },
   },
 );

--- a/packages/sdk/src/scopes/utilities/uncategorized/switchInlineQuery.ts
+++ b/packages/sdk/src/scopes/utilities/uncategorized/switchInlineQuery.ts
@@ -1,6 +1,6 @@
 import type { SwitchInlineQueryChatType } from '@telegram-apps/bridge';
 
-import { postEvent } from '@/globals.js';
+import { launchParams, postEvent } from '@/globals.js';
 import { wrapSafe } from '@/scopes/wrappers/wrapSafe.js';
 
 const SWITCH_INLINE_QUERY_METHOD = 'web_app_switch_inline_query';
@@ -18,6 +18,7 @@ const SWITCH_INLINE_QUERY_METHOD = 'web_app_switch_inline_query';
  * @throws {FunctionNotAvailableError} The function is not supported
  * @throws {FunctionNotAvailableError} The environment is unknown
  * @throws {FunctionNotAvailableError} The SDK is not initialized
+ * @throws {FunctionNotAvailableError} The application must be launched in the inline mode
  * @example
  * if (switchInlineQuery.isAvailable()) {
  *   switchInlineQuery('my query goes here', ['users']);
@@ -31,4 +32,11 @@ export const switchInlineQuery = wrapSafe(
       chat_types: chatTypes || [],
     });
   },
+  {
+    isSupported() {
+      return launchParams().tgWebAppBotInline
+        ? undefined
+        : 'The application must be launched in the inline mode';
+    }
+  }
 );


### PR DESCRIPTION
Fixes #673

⚠️ Not tested ⚠️ 

Working under the following assumptions:
- `tgWebAppData` is equivalent of `WebAppInitData`;
- `tgWebAppData` is set under the same circumstances as `WebAppInitData`;
- `sendData` method is available for mini-apps running from inline mode.

If `tgWebAppData` is not processed as `WebAppInitData` type object is, I suggest to reject this PR.
If `tgWebAppData` is processed more or less the same, but `sendData` is not available for inline mode, additional checks would be required, for example:
```ts
    isSupported() {
      // tgWebAppData is set only when the app is launched
      // via a keyboard button OR from inline mode
      const isDataSet = launchParams().tgWebAppData !== undefined;
      const isLaunchedFromInline = launchParams().tgWebAppBotInline;
      // Since `sendData` is not available from inline mode, we need to:
      // 1. Ensure we don't have `tgWebAppData`
      // 2. Ensure the app is not launched from inline mode
      return (!isDataSet && !isLaunchedFromInline)
        ? 'The application must be launched via a keyboard button'
        : undefined;
    },
```

(If I'm not mistaken in the boolean checks 😅)